### PR TITLE
fix: filter downloaded result by job

### DIFF
--- a/llassist.ApiService/Services/ProjectProcessingService.cs
+++ b/llassist.ApiService/Services/ProjectProcessingService.cs
@@ -62,9 +62,17 @@ public class ProjectProcessingService
         var latestJob = projectJobs.OrderByDescending(j => j.Id).First();
 
         var processedArticles = project.Articles
-            .Where(article => article.ArticleRelevances.Any(relevance => relevance.EstimateRelevanceJobId == latestJob.Id))
-            .Select(article => ModelMappers.ToArticleViewModel(article, latestJob.Id))
+            .Select(article =>
+            {
+                var filteredRelevances = article.ArticleRelevances
+                    .Where(relevance => relevance.EstimateRelevanceJobId == latestJob.Id)
+                    .ToList();
+
+                return filteredRelevances.Count != 0 ? ModelMappers.ToArticleViewModel(article, filteredRelevances) : null;
+            })
+            .Where(articleViewModel => articleViewModel != null)
             .ToList();
+
 
         return new ProcessResultViewModel
         {

--- a/llassist.Common/Mappers/ModelMappers.cs
+++ b/llassist.Common/Mappers/ModelMappers.cs
@@ -59,10 +59,15 @@ public class ModelMappers
 
     private static List<ArticleViewModel> ToArticleViewModels(ICollection<Article> articles)
     {
-        return articles.Select(article => ToArticleViewModel(article, Ulid.Empty)).ToList();
+        return articles.Select(article => ToArticleViewModel(article)).ToList();
     }
 
-    public static ArticleViewModel ToArticleViewModel(Article article, Ulid jobId)
+    public static ArticleViewModel ToArticleViewModel(Article article)
+    {
+        return ToArticleViewModel(article, article.ArticleRelevances);
+    }
+
+    public static ArticleViewModel ToArticleViewModel(Article article, ICollection<ArticleRelevance> articleRelevances)
     {
         return new ArticleViewModel
         {
@@ -71,7 +76,7 @@ public class ModelMappers
             Year = article.Year,
             Abstract = article.Abstract,
             MustRead = article.MustRead,
-            Relevances = ToRelevanceViewModels(article.ArticleRelevances)
+            Relevances = ToRelevanceViewModels(articleRelevances)
         };
     }
 

--- a/llassist.Tests/ModelMappersTests.cs
+++ b/llassist.Tests/ModelMappersTests.cs
@@ -117,10 +117,9 @@ public class ModelMappersTests
                 new ArticleRelevance { Question = "Q2", RelevanceScore = 0.7, IsRelevant = false }
             }
         };
-        var jobId = Ulid.NewUlid();
 
         // Act
-        var result = ModelMappers.ToArticleViewModel(article, jobId);
+        var result = ModelMappers.ToArticleViewModel(article);
 
         // Assert
         Assert.Equal(article.Title, result.Title);


### PR DESCRIPTION
Not only filtering the Article based on whether the Article has Article Relevance from the latest job, we also need to filter the list of Article Relevance so that only relevances from related job are returned with the article.