### PR TITLE
[WIP] Add Library Models for Content Organization

### DIFF
--- a/llassist.ApiService/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/llassist.ApiService/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -22,6 +22,30 @@ namespace llassist.ApiService.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("llassist.Common.Models.AppSetting", b =>
+                {
+                    b.Property<string>("Key")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Key");
+
+                    b.ToTable("AppSettings", (string)null);
+                });
+
             modelBuilder.Entity("llassist.Common.Models.Article", b =>
                 {
                     b.Property<string>("Id")

--- a/llassist.Common/Mappers/ModelMappers.cs
+++ b/llassist.Common/Mappers/ModelMappers.cs
@@ -1,4 +1,5 @@
 ﻿using llassist.Common.Models;
+using llassist.Common.Models.Library;
 using llassist.Common.ViewModels;
 using System.Text.Json;
 
@@ -153,5 +154,232 @@ public class ModelMappers
             });
         }
         return researchQuestionList;
+    }
+
+    // Catalog mapping
+    public static CatalogViewModel ToCatalogViewModel(Catalog catalog)
+    {
+        return new CatalogViewModel
+        {
+            Id = catalog.Id.ToString(),
+            Name = catalog.Name,
+            Description = catalog.Description,
+            Owner = catalog.Owner,
+            CreatedAt = catalog.CreatedAt,
+            Entries = catalog.Entries.Select(ToEntryViewModel).ToList()
+        };
+    }
+
+    // Entry mapping
+    public static EntryViewModel ToEntryViewModel(Entry entry)
+    {
+        return new EntryViewModel
+        {
+            Id = entry.Id.ToString(),
+            EntryType = entry.EntryType,
+            Title = entry.Title,
+            Description = entry.Description,
+            Citation = entry.Citation,
+            Source = entry.Source,
+            Identifier = entry.Identifier,
+            CreatedAt = entry.CreatedAt,
+            PublishedAt = entry.PublishedAt,
+            Resources = entry.Resources.Select(ToResourceViewModel).ToList(),
+            Labels = entry.Labels.Select(l => l.Label.Name).ToList(),
+            Metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(entry.Metadata) 
+                ?? new Dictionary<string, object>()
+        };
+    }
+
+    // Resource mapping
+    public static ResourceViewModel ToResourceViewModel(Resource resource)
+    {
+        return new ResourceViewModel
+        {
+            Id = resource.Id.ToString(),
+            Name = resource.Name,
+            Type = resource.Type,
+            ContentType = resource.ContentType,
+            Size = resource.Size
+        };
+    }
+
+    // Category tree mapping
+    public static CategoryTreeViewModel ToCategoryTreeViewModel(string schemaType, IEnumerable<Category> rootCategories)
+    {
+        return new CategoryTreeViewModel
+        {
+            SchemaType = schemaType,
+            RootCategories = rootCategories
+                .Where(c => c.ParentId == null && c.SchemaType == schemaType)
+                .Select(ToCategoryViewModel)
+                .ToList()
+        };
+    }
+
+    // Category mapping with recursive children
+    public static CategoryViewModel ToCategoryViewModel(Category category)
+    {
+        return new CategoryViewModel
+        {
+            Id = category.Id.ToString(),
+            Name = category.Name,
+            Description = category.Description,
+            Path = category.Path,
+            Depth = category.Depth,
+            SchemaType = category.SchemaType,
+            ParentId = category.ParentId?.ToString(),
+            Children = category.Children.Select(ToCategoryViewModel).ToList(),
+            EntryIds = category.Entries.Select(ce => ce.EntryId.ToString()).ToList()
+        };
+    }
+
+    // Category path mapping for navigation
+    public static CategoryPathViewModel ToCategoryPathViewModel(Category category)
+    {
+        var breadcrumbs = new List<CategoryBreadcrumbViewModel>();
+        var current = category;
+        var pathParts = new List<string>();
+        
+        // Build breadcrumbs and path parts from current category up to root
+        while (current != null)
+        {
+            breadcrumbs.Insert(0, new CategoryBreadcrumbViewModel
+            {
+                Id = current.Id.ToString(),
+                Name = current.Name,
+                Depth = current.Depth
+            });
+            pathParts.Insert(0, current.Name);
+            current = current.Parent;
+        }
+
+        return new CategoryPathViewModel
+        {
+            Id = category.Id.ToString(),
+            Name = category.Name,
+            Path = "/" + string.Join("/", pathParts),
+            Breadcrumbs = breadcrumbs
+        };
+    }
+
+    // Label mapping
+    public static LabelViewModel ToLabelViewModel(Label label)
+    {
+        return new LabelViewModel
+        {
+            Id = label.Id.ToString(),
+            Name = label.Name,
+            Description = label.Description,
+            Color = label.Color
+        };
+    }
+
+    // Helper method to build category paths
+    public static string BuildCategoryPath(Category category)
+    {
+        var pathParts = new List<string>();
+        var current = category;
+        
+        while (current != null)
+        {
+            pathParts.Insert(0, current.Name);
+            current = current.Parent;
+        }
+        
+        return "/" + string.Join("/", pathParts);
+    }
+
+    // Helper method to calculate category depth
+    public static int CalculateCategoryDepth(Category category)
+    {
+        int depth = 0;
+        var current = category;
+        
+        while (current.Parent != null)
+        {
+            depth++;
+            current = current.Parent;
+        }
+        
+        return depth;
+    }
+
+    // Map a list of categories by schema type
+    public static IDictionary<string, CategoryTreeViewModel> ToCategoryTreeViewModels(IEnumerable<Category> categories)
+    {
+        return categories
+            .GroupBy(c => c.SchemaType)
+            .ToDictionary(
+                g => g.Key,
+                g => ToCategoryTreeViewModel(g.Key, g.Where(c => c.ParentId == null))
+            );
+    }
+
+    // Map a flat list of categories with their paths
+    public static IList<CategoryPathViewModel> ToCategoryPathViewModels(IEnumerable<Category> categories)
+    {
+        return categories
+            .Select(ToCategoryPathViewModel)
+            .OrderBy(c => c.Path)
+            .ToList();
+    }
+
+    // Map entry with its category paths
+    public static EntryWithCategoriesViewModel ToEntryWithCategoriesViewModel(Entry entry)
+    {
+        var viewModel = new EntryWithCategoriesViewModel
+        {
+            Id = entry.Id.ToString(),
+            EntryType = entry.EntryType,
+            Title = entry.Title,
+            Description = entry.Description,
+            Citation = entry.Citation,
+            Source = entry.Source,
+            Identifier = entry.Identifier,
+            CreatedAt = entry.CreatedAt,
+            PublishedAt = entry.PublishedAt,
+            Resources = entry.Resources.Select(ToResourceViewModel).ToList(),
+            Labels = entry.Labels.Select(l => l.Label.Name).ToList(),
+            Metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(entry.Metadata) 
+                ?? new Dictionary<string, object>(),
+        };
+
+        // Group categories by schema type
+        foreach (var group in entry.Categories.GroupBy(ce => ce.Category.SchemaType))
+        {
+            viewModel.Categories[group.Key] = group
+                .Select(ce => ToCategoryPathViewModel(ce.Category))
+                .ToList();
+        }
+
+        return viewModel;
+    }
+
+    // Map catalog with category trees
+    public static CatalogWithCategoriesViewModel ToCatalogWithCategoriesViewModel(Catalog catalog)
+    {
+        return new CatalogWithCategoriesViewModel
+        {
+            Id = catalog.Id.ToString(),
+            Name = catalog.Name,
+            Description = catalog.Description,
+            Owner = catalog.Owner,
+            CreatedAt = catalog.CreatedAt,
+            Entries = catalog.Entries.Select(ToEntryViewModel).ToList(),
+            CategoryTrees = ToCategoryTreeViewModels(catalog.Categories)
+        };
+    }
+
+    // Map search results with category paths
+    public static SearchResultViewModel ToSearchResultViewModel(
+        Entry entry, 
+        IEnumerable<CategoryPathViewModel> categoryPaths)
+    {
+        return new SearchResultViewModel
+        {
+            Entry = ToEntryViewModel(entry),
+            CategoryPaths = categoryPaths.ToList()
+        };
     }
 }

--- a/llassist.Common/Models/Library/ArticleReference.cs
+++ b/llassist.Common/Models/Library/ArticleReference.cs
@@ -1,0 +1,16 @@
+ using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Links Articles to Entries
+public class ArticleReference
+{
+    public Ulid ArticleId { get; set; }
+    public Ulid EntryId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    
+    [JsonIgnore]
+    public virtual Article Article { get; set; } = null!;
+    [JsonIgnore]
+    public virtual Entry Entry { get; set; } = null!;
+}

--- a/llassist.Common/Models/Library/Catalog.cs
+++ b/llassist.Common/Models/Library/Catalog.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Root level container for a Library
+public class Catalog : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Owner { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+    
+    public ICollection<Entry> Entries { get; set; } = [];
+    public ICollection<Label> Labels { get; set; } = [];
+    public ICollection<Category> Categories { get; set; } = [];
+} 

--- a/llassist.Common/Models/Library/Category.cs
+++ b/llassist.Common/Models/Library/Category.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Represents a node in hierarchical organization
+public class Category : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;  // Full path like "/science/physics/quantum"
+    public int Depth { get; set; }                    // Depth in hierarchy
+    
+    public Ulid CatalogId { get; set; }
+    public Ulid? ParentId { get; set; }              // Null for root categories
+    
+    [JsonIgnore]
+    public virtual Catalog Catalog { get; set; } = null!;
+    [JsonIgnore]
+    public virtual Category? Parent { get; set; }
+    
+    public ICollection<Category> Children { get; set; } = [];
+    public ICollection<CategoryEntry> Entries { get; set; } = [];
+    
+    public string SchemaType { get; set; } = string.Empty;  // Identifies which classification schema this belongs to
+} 

--- a/llassist.Common/Models/Library/CategoryEntry.cs
+++ b/llassist.Common/Models/Library/CategoryEntry.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Junction table for Category-Entry relationship
+public class CategoryEntry
+{
+    public Ulid CategoryId { get; set; }
+    public Ulid EntryId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    
+    [JsonIgnore]
+    public virtual Category Category { get; set; } = null!;
+    [JsonIgnore]
+    public virtual Entry Entry { get; set; } = null!;
+} 

--- a/llassist.Common/Models/Library/Collection.cs
+++ b/llassist.Common/Models/Library/Collection.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Organization within a catalog
+public class Collection : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+    
+    public Ulid CatalogId { get; set; }
+    [JsonIgnore]
+    public virtual Catalog Catalog { get; set; } = null!;
+    
+    public ICollection<Entry> Entries { get; set; } = [];
+} 

--- a/llassist.Common/Models/Library/Entry.cs
+++ b/llassist.Common/Models/Library/Entry.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Represents a catalog entry
+public class Entry : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public string EntryType { get; set; } = string.Empty;  // academic, web, media, correspondence
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Citation { get; set; } = string.Empty;   // Formatted citation text
+    public string Source { get; set; } = string.Empty;     // Origin/publisher/platform
+    public string Identifier { get; set; } = string.Empty; // DOI/URL/ISBN/etc
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public DateTimeOffset? PublishedAt { get; set; }      // Original publication date
+    
+    public Ulid CatalogId { get; set; }
+    [JsonIgnore]
+    public virtual Catalog Catalog { get; set; } = null!;
+    
+    // Flexible metadata storage
+    public string Metadata { get; set; } = "{}";
+    
+    public ICollection<Resource> Resources { get; set; } = [];
+    public ICollection<EntryLabel> Labels { get; set; } = [];
+    public ICollection<ArticleReference> ArticleReferences { get; set; } = [];
+    public ICollection<CategoryEntry> Categories { get; set; } = [];
+} 

--- a/llassist.Common/Models/Library/EntryLabel.cs
+++ b/llassist.Common/Models/Library/EntryLabel.cs
@@ -1,0 +1,16 @@
+ using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Junction table for Entry-Label relationship
+public class EntryLabel
+{
+    public Ulid EntryId { get; set; }
+    public Ulid LabelId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    
+    [JsonIgnore]
+    public virtual Entry Entry { get; set; } = null!;
+    [JsonIgnore]
+    public virtual Label Label { get; set; } = null!;
+}

--- a/llassist.Common/Models/Library/Label.cs
+++ b/llassist.Common/Models/Library/Label.cs
@@ -1,0 +1,16 @@
+ using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Label for categorization within a Catalog
+public class Label : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Color { get; set; } = string.Empty;
+    public Ulid CatalogId { get; set; }
+    
+    [JsonIgnore]
+    public virtual Catalog Catalog { get; set; } = null!;
+}

--- a/llassist.Common/Models/Library/Resource.cs
+++ b/llassist.Common/Models/Library/Resource.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace llassist.Common.Models.Library;
+
+// Represents any attached resource
+public class Resource : IEntity<Ulid>
+{
+    public Ulid Id { get; set; } = Ulid.NewUlid();
+    public Ulid EntryId { get; set; }
+    
+    [JsonIgnore]
+    public virtual Entry Entry { get; set; } = null!;
+    
+    public string Name { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;      // file, url, embedded
+    public string ContentType { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public string Hash { get; set; } = string.Empty;      // For integrity check
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+} 

--- a/llassist.Common/ViewModels/LibraryViewModels.cs
+++ b/llassist.Common/ViewModels/LibraryViewModels.cs
@@ -1,0 +1,96 @@
+namespace llassist.Common.ViewModels;
+
+public class CatalogViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Owner { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public IList<EntryViewModel> Entries { get; set; } = [];
+}
+
+public class EntryViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string EntryType { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Citation { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string Identifier { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? PublishedAt { get; set; }
+    public IList<ResourceViewModel> Resources { get; set; } = [];
+    public IList<string> Labels { get; set; } = [];
+    public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
+}
+
+public class ResourceViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string ContentType { get; set; } = string.Empty;
+    public long Size { get; set; }
+}
+
+public class LabelViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Color { get; set; } = string.Empty;
+}
+
+public class CategoryViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public int Depth { get; set; }
+    public string SchemaType { get; set; } = string.Empty;
+    public string? ParentId { get; set; }
+    public IList<CategoryViewModel> Children { get; set; } = [];
+    public IList<string> EntryIds { get; set; } = [];
+}
+
+public class CategoryTreeViewModel
+{
+    public string SchemaType { get; set; } = string.Empty;
+    public IList<CategoryViewModel> RootCategories { get; set; } = [];
+}
+
+public class CategoryPathViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public IList<CategoryBreadcrumbViewModel> Breadcrumbs { get; set; } = [];
+}
+
+public class CategoryBreadcrumbViewModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int Depth { get; set; }
+}
+
+public class EntryWithCategoriesViewModel : EntryViewModel
+{
+    public IDictionary<string, IList<CategoryPathViewModel>> Categories { get; set; }
+        = new Dictionary<string, IList<CategoryPathViewModel>>();
+}
+
+public class CatalogWithCategoriesViewModel : CatalogViewModel
+{
+    public IDictionary<string, CategoryTreeViewModel> CategoryTrees { get; set; } 
+        = new Dictionary<string, CategoryTreeViewModel>();
+}
+
+public class SearchResultViewModel
+{
+    public EntryViewModel Entry { get; set; } = new EntryViewModel();
+    public IList<CategoryPathViewModel> CategoryPaths { get; set; } = [];
+} 

--- a/llassist.Tests/LibraryMapperTests.cs
+++ b/llassist.Tests/LibraryMapperTests.cs
@@ -1,0 +1,245 @@
+using llassist.Common.Mappers;
+using llassist.Common.Models.Library;
+using llassist.Common.ViewModels;
+using Xunit;
+using Assert = Xunit.Assert;
+using System.Text.Json;
+
+namespace llassist.Tests;
+
+public class LibraryMapperTests
+{
+    [Fact]
+    public void ToCatalogViewModel_MapsAllProperties()
+    {
+        // Arrange
+        var catalog = new Catalog
+        {
+            Id = Ulid.NewUlid(),
+            Name = "Test Catalog",
+            Description = "Test Description",
+            Owner = "Test Owner",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToCatalogViewModel(catalog);
+
+        // Assert
+        Assert.Equal(catalog.Id.ToString(), viewModel.Id);
+        Assert.Equal(catalog.Name, viewModel.Name);
+        Assert.Equal(catalog.Description, viewModel.Description);
+        Assert.Equal(catalog.Owner, viewModel.Owner);
+        Assert.Equal(catalog.CreatedAt, viewModel.CreatedAt);
+    }
+
+    [Fact]
+    public void ToCategoryTreeViewModel_BuildsHierarchy()
+    {
+        // Arrange
+        var catalogId = Ulid.NewUlid();
+        var root = new Category 
+        { 
+            Id = Ulid.NewUlid(),
+            Name = "Root",
+            SchemaType = "subject",
+            CatalogId = catalogId
+        };
+        
+        var child = new Category
+        {
+            Id = Ulid.NewUlid(),
+            Name = "Child",
+            SchemaType = "subject",
+            CatalogId = catalogId,
+            Parent = root
+        };
+        
+        root.Children.Add(child);
+        var categories = new[] { root };
+
+        // Act
+        var viewModel = ModelMappers.ToCategoryTreeViewModel("subject", categories);
+
+        // Assert
+        Assert.Single(viewModel.RootCategories);
+        Assert.Equal("subject", viewModel.SchemaType);
+        Assert.Single(viewModel.RootCategories[0].Children);
+        Assert.Equal(root.Name, viewModel.RootCategories[0].Name);
+        Assert.Equal(child.Name, viewModel.RootCategories[0].Children[0].Name);
+    }
+
+    [Fact]
+    public void ToCategoryPathViewModel_BuildsBreadcrumbs()
+    {
+        // Arrange
+        var root = new Category 
+        { 
+            Name = "Root", 
+            Depth = 0,
+            Path = "/Root"
+        };
+        var child = new Category 
+        { 
+            Name = "Child", 
+            Parent = root, 
+            Depth = 1,
+            Path = "/Root/Child"
+        };
+        var grandChild = new Category 
+        { 
+            Name = "GrandChild", 
+            Parent = child, 
+            Depth = 2,
+            Path = "/Root/Child/GrandChild"
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToCategoryPathViewModel(grandChild);
+
+        // Assert
+        Assert.Equal(3, viewModel.Breadcrumbs.Count);
+        Assert.Equal("Root", viewModel.Breadcrumbs[0].Name);
+        Assert.Equal("Child", viewModel.Breadcrumbs[1].Name);
+        Assert.Equal("GrandChild", viewModel.Breadcrumbs[2].Name);
+        Assert.Equal("/Root/Child/GrandChild", viewModel.Path);
+    }
+
+    [Fact]
+    public void ToEntryWithCategoriesViewModel_GroupsBySchema()
+    {
+        // Arrange
+        var scienceCategory = new Category 
+        { 
+            Name = "Science",
+            SchemaType = "subject",
+            Path = "/Science"
+        };
+        
+        var physicsCategory = new Category 
+        { 
+            Name = "Physics",
+            SchemaType = "subject",
+            Path = "/Science/Physics",
+            Parent = scienceCategory
+        };
+        
+        var decadeCategory = new Category 
+        { 
+            Name = "2020s",
+            SchemaType = "year",
+            Path = "/2020s"
+        };
+        
+        var yearCategory = new Category 
+        { 
+            Name = "2023",
+            SchemaType = "year",
+            Path = "/2020s/2023",
+            Parent = decadeCategory
+        };
+
+        var entry = new Entry
+        {
+            Id = Ulid.NewUlid(),
+            Title = "Test Entry",
+            Categories = new List<CategoryEntry>
+            {
+                new() 
+                { 
+                    Category = physicsCategory
+                },
+                new() 
+                { 
+                    Category = yearCategory
+                }
+            }
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToEntryWithCategoriesViewModel(entry);
+
+        // Assert
+        Assert.Equal(2, viewModel.Categories.Count);
+        Assert.True(viewModel.Categories.ContainsKey("subject"));
+        Assert.True(viewModel.Categories.ContainsKey("year"));
+        Assert.Equal("/Science/Physics", viewModel.Categories["subject"][0].Path);
+        Assert.Equal("/2020s/2023", viewModel.Categories["year"][0].Path);
+    }
+
+    [Fact]
+    public void ToCatalogWithCategoriesViewModel_IncludesCategoryTrees()
+    {
+        // Arrange
+        var catalog = new Catalog
+        {
+            Id = Ulid.NewUlid(),
+            Name = "Test Catalog",
+            Categories = new List<Category>
+            {
+                new() 
+                { 
+                    Name = "Science",
+                    SchemaType = "subject",
+                    Children = new List<Category>
+                    {
+                        new() { Name = "Physics", SchemaType = "subject" }
+                    }
+                },
+                new() 
+                { 
+                    Name = "2020s",
+                    SchemaType = "decade",
+                    Children = new List<Category>
+                    {
+                        new() { Name = "2023", SchemaType = "decade" }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToCatalogWithCategoriesViewModel(catalog);
+
+        // Assert
+        Assert.Equal(2, viewModel.CategoryTrees.Count);
+        Assert.True(viewModel.CategoryTrees.ContainsKey("subject"));
+        Assert.True(viewModel.CategoryTrees.ContainsKey("decade"));
+        Assert.Single(viewModel.CategoryTrees["subject"].RootCategories);
+        Assert.Single(viewModel.CategoryTrees["decade"].RootCategories);
+    }
+
+    [Fact]
+    public void ToSearchResultViewModel_IncludesCategoryPaths()
+    {
+        // Arrange
+        var entry = new Entry
+        {
+            Id = Ulid.NewUlid(),
+            Title = "Test Entry"
+        };
+
+        var categoryPaths = new[]
+        {
+            new CategoryPathViewModel 
+            { 
+                Name = "Physics",
+                Path = "/Science/Physics",
+                Breadcrumbs = new List<CategoryBreadcrumbViewModel>
+                {
+                    new() { Name = "Science", Depth = 0 },
+                    new() { Name = "Physics", Depth = 1 }
+                }
+            }
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToSearchResultViewModel(entry, categoryPaths);
+
+        // Assert
+        Assert.Equal(entry.Title, viewModel.Entry.Title);
+        Assert.Single(viewModel.CategoryPaths);
+        Assert.Equal("/Science/Physics", viewModel.CategoryPaths[0].Path);
+        Assert.Equal(2, viewModel.CategoryPaths[0].Breadcrumbs.Count);
+    }
+} 

--- a/llassist.Tests/LibraryModelTests.cs
+++ b/llassist.Tests/LibraryModelTests.cs
@@ -1,0 +1,61 @@
+using llassist.Common.Mappers;
+using llassist.Common.Models.Library;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace llassist.Tests;
+
+public class LibraryModelTests
+{
+    [Fact]
+    public void Catalog_InitializesCollections()
+    {
+        // Arrange & Act
+        var catalog = new Catalog();
+
+        // Assert
+        Assert.NotNull(catalog.Entries);
+        Assert.NotNull(catalog.Labels);
+        Assert.NotNull(catalog.Categories);
+        Assert.Empty(catalog.Entries);
+        Assert.Empty(catalog.Labels);
+        Assert.Empty(catalog.Categories);
+    }
+
+    [Fact]
+    public void Category_CalculatesPathAndDepth()
+    {
+        // Arrange
+        var root = new Category { Name = "Science" };
+        var physics = new Category { Name = "Physics", Parent = root };
+        var quantum = new Category { Name = "Quantum", Parent = physics };
+
+        // Act
+        var path = ModelMappers.BuildCategoryPath(quantum);
+        var depth = ModelMappers.CalculateCategoryDepth(quantum);
+
+        // Assert
+        Assert.Equal("/Science/Physics/Quantum", path);
+        Assert.Equal(2, depth);
+    }
+
+    [Fact]
+    public void Entry_HandlesMetadata()
+    {
+        // Arrange
+        var entry = new Entry
+        {
+            Title = "Test Entry",
+            Metadata = """{"key": "value", "number": 42}"""
+        };
+
+        // Act
+        var viewModel = ModelMappers.ToEntryViewModel(entry);
+
+        // Assert
+        Assert.NotNull(viewModel.Metadata);
+        Assert.Equal(2, viewModel.Metadata.Count);
+        Assert.True(viewModel.Metadata.ContainsKey("key"));
+        Assert.True(viewModel.Metadata.ContainsKey("number"));
+    }
+} 


### PR DESCRIPTION
## Overview
- Adds data models and mappers for organizing research content.
- Enables hierarchical categorization, metadata management, and structured content organization.

## Changes
- **Catalog**: Root container for research content
- **Entry**: Content model for research materials with metadata support
- **Category**: Hierarchical classification with path-based organization
- **Resource**: File and reference management
- **Label**: Flexible tagging system
- **View Models**: UI-ready data structures with proper mapping

## Technical Details
- JSON-based metadata storage
- Path-based category hierarchy (/parent/child)
- Support for multiple classification schemas
- Comprehensive mapper implementation with view models
- Added unit tests for models and mappers

## WIP
- Database repository
- API controller
- FE implementation

Closes #[Issue number]